### PR TITLE
Update Gemfile.lock

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -21,7 +21,7 @@ GEM
       i18n (~> 0.7)
       jekyll-sass-converter (~> 1.0)
       jekyll-watch (~> 2.0)
-      kramdown (~> 1.14)
+      kramdown (~> 2.3.1)
       liquid (~> 4.0)
       mercenary (~> 0.3.3)
       pathutil (~> 0.9)


### PR DESCRIPTION
chore: update kramdown to a newer version 2.3.1, to avoid security issue